### PR TITLE
ページを全てClientComponentに

### DIFF
--- a/app/actions/checkSupabaseInteractive.ts
+++ b/app/actions/checkSupabaseInteractive.ts
@@ -1,0 +1,12 @@
+'use server'
+
+import { createClient } from '@/utils/supabase/server'
+
+export default async function checkSupabaseInteractive(): Promise<boolean> {
+  try {
+    createClient()
+    return true
+  } catch (e) {
+    return false
+  }
+}

--- a/app/actions/getUserIfLoggedIn.ts
+++ b/app/actions/getUserIfLoggedIn.ts
@@ -1,0 +1,17 @@
+'use server'
+
+import { createClient } from '@/utils/supabase/server'
+import { User } from '@supabase/supabase-js'
+
+export default async function getUserIfLoggedIn(): Promise<User | null> {
+  const supabase = createClient()
+  if (!supabase || !supabase.auth) {
+    return null
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  return user
+}

--- a/app/actions/signout.ts
+++ b/app/actions/signout.ts
@@ -1,0 +1,11 @@
+'use server'
+
+import { createClient } from '@/utils/supabase/server'
+import { redirect } from 'next/navigation'
+
+export default async function signOut() {
+
+  const supabase = createClient()
+  await supabase.auth.signOut()
+  return redirect('/')
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,28 +1,26 @@
+'use client'
+
 import AuthButton from '../components/AuthButton'
-import { createClient } from '@/utils/supabase/server'
 import ConnectSupabaseSteps from '@/components/tutorial/ConnectSupabaseSteps'
 import SignUpUserSteps from '@/components/tutorial/SignUpUserSteps'
 import Header from '@/components/Header'
+import checkSupabaseInteractive from './actions/checkSupabaseInteractive'
+import { useEffect, useState } from 'react'
+import Loading from '@/components/tutorial/Loading'
 
-export default async function Index() {
-  const canInitSupabaseClient = () => {
-    // This function is just for the interactive tutorial.
-    // Feel free to remove it once you have Supabase connected.
-    try {
-      createClient()
-      return true
-    } catch (e) {
-      return false
-    }
-  }
-
-  const isSupabaseConnected = canInitSupabaseClient()
+export default function Index() {
+  const [isSupabaseConnected, setIsSupabaseConnected] = useState<
+    boolean | string
+  >('loading')
+  useEffect(() => {
+    checkSupabaseInteractive().then(setIsSupabaseConnected)
+  }, [])
 
   return (
     <div className="flex-1 w-full flex flex-col gap-20 items-center">
       <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
         <div className="w-full max-w-4xl flex justify-end items-center p-3 text-sm">
-          {isSupabaseConnected && <AuthButton />}
+          <AuthButton />
         </div>
       </nav>
 
@@ -30,7 +28,9 @@ export default async function Index() {
         <Header />
         <main className="flex-1 flex flex-col gap-6 px-4">
           <h2 className="font-bold text-2xl mb-4">Next steps</h2>
-          {isSupabaseConnected ? <SignUpUserSteps /> : <ConnectSupabaseSteps />}
+          {isSupabaseConnected === 'loading' && <Loading />}
+          {isSupabaseConnected === true && <SignUpUserSteps />}
+          {isSupabaseConnected === false && <ConnectSupabaseSteps />}
         </main>
       </div>
 

--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -1,45 +1,42 @@
-import { createClient } from '@/utils/supabase/server'
+'use client'
+
+import getUserIfLoggedIn from '@/app/actions/getUserIfLoggedIn'
+import signOut from '@/app/actions/signout'
+import { User } from '@supabase/supabase-js'
 import Link from 'next/link'
-import { redirect } from 'next/navigation'
+import { useEffect, useState } from 'react'
 
-export default async function AuthButton() {
-  const supabase = createClient()
+export default function AuthButton() {
+  const [user, setUser] = useState<User | null>(null)
+  useEffect(() => {
+    getUserIfLoggedIn().then(setUser)
+  }, [])
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  const signOut = async () => {
-    'use server'
-
-    const supabase = createClient()
-    await supabase.auth.signOut()
-    return redirect('/')
-  }
-
-  return user ? (
+  return (
     <div className="flex items-center gap-4">
-      Hey, {user.phone}!
-      <Link
-        href="/protected/change-phone"
-        className="py-2 px-4 flex items-center justify-center rounded-md no-underline bg-btn-background hover:bg-btn-background-hover text-sm font-medium"
-      >
-        Change phone
-      </Link>
-      <form action={signOut}>
-        <button className="py-2 px-4 rounded-md no-underline bg-btn-background hover:bg-btn-background-hover">
-          Logout
-        </button>
-      </form>
-    </div>
-  ) : (
-    <div className="flex gap-2">
-      <Link
-        href="/signup"
-        className="h-8 flex items-center justify-center rounded-md no-underline bg-black text-white text-sm font-medium px-4"
-      >
-        Sign up/Log in
-      </Link>
+      {user ? (
+        <>
+          Hey, {user.phone}!
+          <Link
+            href="/protected/change-phone"
+            className="py-2 px-4 flex items-center justify-center rounded-md no-underline bg-btn-background hover:bg-btn-background-hover text-sm font-medium"
+          >
+            Change phone
+          </Link>
+          <form action={signOut}>
+            <button className="py-2 px-4 rounded-md no-underline bg-btn-background hover:bg-btn-background-hover">
+              Logout
+            </button>
+          </form>
+        </>
+      ) : (
+        <Link
+          href="/signup"
+          className="h-8 flex items-center justify-center rounded-md no-underline bg-btn-background hover:bg-btn-background-hover text-sm font-medium px-4"
+        >
+          Sign up/Log in
+        </Link>
+      )}
     </div>
   )
 }

--- a/components/tutorial/Loading.tsx
+++ b/components/tutorial/Loading.tsx
@@ -1,0 +1,11 @@
+import Step from './Step'
+
+export default function SignUpUserSteps() {
+  return (
+    <ol className="flex flex-col gap-6">
+      <Step title="Sign up your first user">
+        <p>Loading...</p>
+      </Step>
+    </ol>
+  )
+}

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,3 +1,5 @@
+'use server'
+
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 


### PR DESCRIPTION
サーバーサイドレンダリングを多用していたが、 https://passage.id/ の利用にあたりフロントエンドとバックエンドの分割が明確であるため、それらに対応できるように全てClientComponentに変更した